### PR TITLE
Add Claude Code GitHub Actions workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,55 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      github.actor == 'christiangroth' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Download dependencies
+        run: ./gradlew dependencies
+        env:
+          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--allowedTools Edit,MultiEdit,Write,Glob,Grep,LS,Read,Bash(git:*),Bash(./gradlew:*),Bash(gh:*)"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_PAT: ${{ secrets.GHCR_PAT }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# CLAUDE.md for quarkus-one-time-starters
+
+## Build & Test Commands
+
+```bash
+# Run full build (includes tests and static analysis)
+./gradlew build
+
+# Run tests only
+./gradlew test
+
+```
+
+## Documentation
+
+- **Architecture:** [docs/arc42.md](docs/arc42.md)
+
+## Release Note Snippets
+
+**Snippet filename:** `docs/releasenotes/snippets/{branch-last-segment}-{type}.md` where `{type}` is one of `bugfix` or `feature`.
+
+**Snippet content:** Briefly describe what was changed or added on the branch. Each line should follow the pattern `* Description of the change(s).` Feel free to use multiple short lines, describing the change without technical detail. Only include **user-facing or dependency changes** in release notes. Do not add implementation details, refactoring notes, or internal structural changes (e.g. package renames, build task additions).
+
+**Type selection:** Use `feature` for new user-facing functionality. Use `bugfix` for fixes and chore/internal changes (e.g. refactoring, configuration restructuring, dependency updates).


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude.yml`, mirroring the Claude Code workflow already used in `james-platform` and `spotify-control` (triggered by `@claude` mentions in issues/PR comments/reviews, restricted to `christiangroth`).
- Adds `CLAUDE.md`, copied from the existing `.github/copilot-instructions.md`.

## Note
This repo does not yet have the `CLAUDE_CODE_OAUTH_TOKEN` secret configured, so the workflow will fail until that secret is added in repo settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)