### PR TITLE
Add Formatting and Green Build Requirement sections to CLAUDE.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,6 +11,25 @@
 
 ```
 
+## Green Build Requirement
+
+**CI must be green before merging a PR into `main`.** The `gradle.yml` workflow runs `./gradlew build` on every push, to any branch — there is no `branches: [main]` filter, so every commit is validated automatically.
+
+- Run `./gradlew build` locally before pushing, to catch failures before they show up in Actions.
+- If CI fails on a PR, fix the underlying issue — do not bypass it.
+- Only use `[no ci]` in a commit message for changes that cannot affect the build (e.g. workflow or doc-only commits) — never to skip validation of code changes.
+
+## Formatting
+
+All code must follow the formatting rules in `.editorconfig`. The most important rules:
+
+- **2-space indentation**, no tabs
+- **CRLF line endings**
+- **Max line length:** 180 characters
+- **Insert final newline** in every file
+
+Always format new and edited files according to `.editorconfig` before committing.
+
 ## Documentation
 
 - **Architecture:** [docs/arc42.md](../docs/arc42.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,25 @@
 
 ```
 
+## Green Build Requirement
+
+**CI must be green before merging a PR into `main`.** The `gradle.yml` workflow runs `./gradlew build` on every push, to any branch — there is no `branches: [main]` filter, so every commit is validated automatically.
+
+- Run `./gradlew build` locally before pushing, to catch failures before they show up in Actions.
+- If CI fails on a PR, fix the underlying issue — do not bypass it.
+- Only use `[no ci]` in a commit message for changes that cannot affect the build (e.g. workflow or doc-only commits) — never to skip validation of code changes.
+
+## Formatting
+
+All code must follow the formatting rules in `.editorconfig`. The most important rules:
+
+- **2-space indentation**, no tabs
+- **CRLF line endings**
+- **Max line length:** 180 characters
+- **Insert final newline** in every file
+
+Always format new and edited files according to `.editorconfig` before committing.
+
 ## Documentation
 
 - **Architecture:** [docs/arc42.md](docs/arc42.md)


### PR DESCRIPTION
Extends `CLAUDE.md` (and the derived `.github/copilot-instructions.md`) with a **Formatting** section referencing `.editorconfig` and a **Green Build Requirement** section, using `spotify-control`'s `CLAUDE.md` as a structural reference.

Refs #31.

Generated with [Claude Code](https://claude.ai/code)