### PR TITLE
Harden Claude Code workflow: foreground builds, PR completion contract, incremental commits

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -52,6 +52,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
           branch_prefix: "claude-"
+          display_report: true
           claude_args: |
             --allowedTools Edit,MultiEdit,Write,TodoWrite,Glob,Grep,LS,Read,BashOutput,KillShell,Bash(git:*),Bash(./gradlew:*),Bash(gh:*)
             --append-system-prompt "Before opening a PR, check with 'gh pr list --head <branch>' whether one is already open for the branch - if so, use 'gh pr edit' instead of opening a second one. Follow CLAUDE.md for the build strategy (section 'Running Gradle in Time-Limited Agent Sessions') and the completion criteria (sections 'Task Completion' and 'Incremental Commits')."

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,6 +21,7 @@ jobs:
       )
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write
       pull-requests: write
       issues: write
@@ -29,7 +30,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Set up Java
         uses: actions/setup-java@v4
@@ -49,7 +50,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--allowedTools Edit,MultiEdit,Write,Glob,Grep,LS,Read,Bash(git:*),Bash(./gradlew:*),Bash(gh:*)"
+          track_progress: true
+          branch_prefix: "claude-"
+          claude_args: |
+            --allowedTools Edit,MultiEdit,Write,TodoWrite,Glob,Grep,LS,Read,BashOutput,KillShell,Bash(git:*),Bash(./gradlew:*),Bash(gh:*)
+            --append-system-prompt "Before opening a PR, check with 'gh pr list --head <branch>' whether one is already open for the branch - if so, use 'gh pr edit' instead of opening a second one. Follow CLAUDE.md for the build strategy (section 'Running Gradle in Time-Limited Agent Sessions') and the completion criteria (sections 'Task Completion' and 'Incremental Commits')."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GHCR_PAT: ${{ secrets.GHCR_PAT }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,28 @@
 - Run `./gradlew build` locally before pushing, to catch failures before they show up in Actions.
 - If CI fails on a PR, fix the underlying issue — do not bypass it.
 - Only use `[no ci]` in a commit message for changes that cannot affect the build (e.g. workflow or doc-only commits) — never to skip validation of code changes.
+- **Exception for time-limited agent sessions:** see "Running Gradle in Time-Limited Agent Sessions" below.
+
+## Running Gradle in Time-Limited Agent Sessions
+
+This applies whenever a single command execution is time-limited (e.g. the Claude Code GitHub Action, whose Bash tool has a hard execution ceiling of a few minutes per call). A full `./gradlew build` (tests, static analysis) can exceed that ceiling and gets killed at an inconsistent point from run to run — do not rely on it in this context.
+
+- **Never background a Gradle invocation** (no `run_in_background` / async execution). A build that keeps running after its tool call is considered "timed out" produces results that cannot be trusted or awaited.
+- **Scope the build to what you touched** for a fast, reliable local signal, e.g. `./gradlew test` for a quick check instead of the whole-repo `build`.
+- **Push the branch and open the PR**, then rely on the `gradle.yml` workflow (triggered automatically on every push) as the authoritative full-build gate. Poll with `gh pr checks` (short, non-blocking calls) to confirm it goes green rather than reproducing the whole build locally.
+
+## Task Completion
+
+A task is only complete once:
+1. The relevant tests/checks for what you touched are green (see above), and CI on the pushed branch is green or at least running.
+2. Changes are committed and pushed.
+3. A pull request is open via `gh pr create` — check first with `gh pr list --head <branch>` whether one already exists for the branch; if so, use `gh pr edit` instead of opening a second one.
+
+Never end a task with "PR still to be opened" as an open item, and never end silently after a partial change. If a step fails (e.g. `git push` or `gh pr create`), retry (e.g. with a different branch name); if it still fails, state the failure and the reason explicitly in a comment. If, after investigation, no code change turns out to be needed, say so explicitly in a comment instead of ending without any response.
+
+## Incremental Commits
+
+Don't wait until the very end and bundle everything into one commit: commit and push after each self-contained step. As soon as the first meaningful commit is pushed, open a draft pull request (`gh pr create --draft`) and keep updating its description as work progresses; only take it out of draft once everything is done. This way, even an interrupted run leaves a visible trace instead of ending without one.
 
 ## Formatting
 


### PR DESCRIPTION
## Summary
- Never background `./gradlew`/`mvn` invocations in the Claude Code Action - the Bash tool's hard timeout ceiling kills background tasks the same way it kills foreground ones, so backgrounding was masking failures instead of avoiding them.
- Scope builds/tests to what was touched, run them in the foreground, and rely on the branch's own CI run (or the repo's local-scoped-build rule) as the real gate.
- `CLAUDE.md` now has an explicit Task Completion contract: branch -> commit -> push -> PR is mandatory, no silent endings, retry on failure, duplicate-PR check via `gh pr list --head`.
- Incremental commits: commit/push after each self-contained step and open a draft PR early instead of bundling everything into one commit at the end.
- `fetch-depth: 0`, `track_progress: true`, `branch_prefix: "claude-"` (avoids the `/`-encoding 404 bug in claude-code-action#589).

## Test plan
- [ ] Trigger `@claude` on an issue/PR comment and confirm a branch + PR appear even for a longer task
- [ ] Confirm no Gradle/Maven invocation is backgrounded during the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)